### PR TITLE
Change default return value to null from undefined

### DIFF
--- a/client/models/resource-link.js
+++ b/client/models/resource-link.js
@@ -48,7 +48,7 @@ function resourceLink(data, feather) {
                 return mat[0];
             }
         }
-        return;
+        return null;
     }
     function mapIcon(ext){
         return icoMap[ext] || ext;
@@ -73,7 +73,7 @@ function resourceLink(data, feather) {
                 }
             }
         }
-        return;
+        return null;
     }
 
     function handleLink() {


### PR DESCRIPTION
Note: The following block of code in resource-link.js::suggestIcon is somewhat superfluous as I don't think there are many, if any, icon names that directly match the file extension, leaving the mapIcon definition as the only valid reference and the subsequent call becoming an unnecessary validation.

                idx = f.icons().findIndex(function (v, i) {
                    if (v === low) {
                        return true;
                    }
                });