### PR TITLE
Add optional SSL configuration for PG connections

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -15,6 +15,10 @@
     "pgPort": 5432,
     "pgUser": "admin",
     "pgPassword": "password",
+    "ssl": false,
+    "pgSslCA": "./server/ssl/root.crt",
+    "pgSslKey": "./server/ssl/server.key",
+    "pgSslCert": "./server/ssl/server.crt",
     "secret": "Your own session key here",
     "sessionTimeout": 86400000,
     "npmModules": []

--- a/server/database.js
+++ b/server/database.js
@@ -23,6 +23,7 @@
 (function (exports) {
     "use strict";
 
+    const fs = require("fs");
     const {Pool} = require("pg");
     const {Config} = require("./config");
     const f = require("../common/core");
@@ -52,13 +53,25 @@
         // Reslove connection string
         function setConfig(resp) {
             return new Promise(function (resolve) {
+
+                let sslCfg;
+                if(resp.ssl){
+                    sslCfg = {
+                        ca: fs.readFileSync(resp.pgSslCA).toString(),
+                        cert: fs.readFileSync(resp.pgSslCert).toString(),
+                        key: fs.readFileSync(resp.pgSslKey).toString(),
+                        rejectUnauthorized: false
+                    };
+                }
+
                 cache = {
                     postgres: {
                         host: resp.pgHost,
                         port: resp.pgPort,
                         database: resp.pgDatabase,
                         user: resp.pgUser,
-                        password: resp.pgPassword
+                        password: resp.pgPassword,
+                        ssl: sslCfg
                     }
                 };
                 resolve(resp);
@@ -92,13 +105,24 @@
                 function doConnect(resp) {
                     return new Promise(function (resolve, reject) {
                         let login;
+                        let sslCfg;
+
+                        if(resp.ssl){
+                            sslCfg = {
+                                ca: fs.readFileSync(resp.pgSslCA).toString(),
+                                cert: fs.readFileSync(resp.pgSslCert).toString(),
+                                key: fs.readFileSync(resp.pgSslKey).toString(),
+                                rejectUnauthorized: false
+                            };
+                        }
 
                         login = new Pool({
                             host: resp.pgHost,
                             database: resp.pgDatabase,
                             user: username,
                             password: pswd,
-                            port: resp.pgPort
+                            port: resp.pgPort,
+                            ssl : sslCfg
                         });
 
                         login.connect(function (err, ignore, done) {

--- a/server/database.js
+++ b/server/database.js
@@ -64,7 +64,7 @@
                 ca: caCfg,
                 cert: certCfg,
                 key: keyCfg,
-                rejectUnauthorized: false
+                rejectUnauthorized: (props.pgRejectUnauthorized || false)
             };
         }
         return sslCfg;

--- a/server/database.js
+++ b/server/database.js
@@ -40,6 +40,37 @@
         };
     }
 
+    function sslConfig(props){
+        let sslCfg;
+
+        if(props.ssl){
+            let caCfg;
+            let certCfg;
+            let keyCfg;
+            if(props.pgSslCA){
+                caCfg = fs.readFileSync(
+                    props.pgSslCA
+                ).toString();
+            }
+            if(props.pgSslCert){
+                certCfg = fs.readFileSync(
+                    props.pgSslCert
+                ).toString();
+            }
+            if(props.pgSslKey){
+                keyCfg = fs.readFileSync(props.pgSslKey).toString();
+            }
+            sslCfg = {
+                ca: caCfg,
+                cert: certCfg,
+                key: keyCfg,
+                rejectUnauthorized: false
+            };
+        }
+        return sslCfg;
+    }
+
+
     /**
         Class for managing database connectivity functions.
         @class Database
@@ -54,15 +85,7 @@
         function setConfig(resp) {
             return new Promise(function (resolve) {
 
-                let sslCfg;
-                if(resp.ssl){
-                    sslCfg = {
-                        ca: fs.readFileSync(resp.pgSslCA).toString(),
-                        cert: fs.readFileSync(resp.pgSslCert).toString(),
-                        key: fs.readFileSync(resp.pgSslKey).toString(),
-                        rejectUnauthorized: false
-                    };
-                }
+
 
                 cache = {
                     postgres: {
@@ -71,7 +94,7 @@
                         database: resp.pgDatabase,
                         user: resp.pgUser,
                         password: resp.pgPassword,
-                        ssl: sslCfg
+                        ssl: sslConfig(resp)
                     }
                 };
                 resolve(resp);
@@ -105,24 +128,13 @@
                 function doConnect(resp) {
                     return new Promise(function (resolve, reject) {
                         let login;
-                        let sslCfg;
-
-                        if(resp.ssl){
-                            sslCfg = {
-                                ca: fs.readFileSync(resp.pgSslCA).toString(),
-                                cert: fs.readFileSync(resp.pgSslCert).toString(),
-                                key: fs.readFileSync(resp.pgSslKey).toString(),
-                                rejectUnauthorized: false
-                            };
-                        }
-
                         login = new Pool({
                             host: resp.pgHost,
                             database: resp.pgDatabase,
                             user: username,
                             password: pswd,
                             port: resp.pgPort,
-                            ssl : sslCfg
+                            ssl : sslConfig(resp)
                         });
 
                         login.connect(function (err, ignore, done) {


### PR DESCRIPTION
The certificates must be the ones configured for the postgresql database. 

Note: Receiving a bad property lint error and a line too long error.